### PR TITLE
Custom shader on Bevy-0.7 (in Japanese)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "breakout"
-version = "0.1.1"
+version = "0.2.0-phase1"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,8 @@ edition = "2021"
 [dependencies]
 bevy = "0.7"
 rand = "0.8"
+
+[[example]]
+name = "anim"
+path = "ref/animate_shader.rs"
+

--- a/assets/shaders/animate_shader.wgsl
+++ b/assets/shaders/animate_shader.wgsl
@@ -1,0 +1,72 @@
+#import bevy_pbr::mesh_view_bind_group
+#import bevy_pbr::mesh_struct
+
+[[group(1), binding(0)]]
+var<uniform> mesh: Mesh;
+
+struct Vertex {
+    [[location(0)]] position: vec3<f32>;
+    [[location(1)]] normal: vec3<f32>;
+    [[location(2)]] uv: vec2<f32>;
+};
+
+struct VertexOutput {
+    [[builtin(position)]] clip_position: vec4<f32>;
+    [[location(0)]] uv: vec2<f32>;
+};
+
+[[stage(vertex)]]
+fn vertex(vertex: Vertex) -> VertexOutput {
+    let world_position = mesh.model * vec4<f32>(vertex.position, 1.0);
+
+    var out: VertexOutput;
+    out.clip_position = view.view_proj * world_position;
+    out.uv = vertex.uv;
+    return out;
+}
+
+
+struct Time {
+    time_since_startup: f32;
+};
+[[group(2), binding(0)]]
+var<uniform> time: Time;
+
+
+fn oklab_to_linear_srgb(c: vec3<f32>) -> vec3<f32> {
+    let L = c.x;
+    let a = c.y;
+    let b = c.z;
+
+    let l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+    let m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+    let s_ = L - 0.0894841775 * a - 1.2914855480 * b;
+
+    let l = l_*l_*l_;
+    let m = m_*m_*m_;
+    let s = s_*s_*s_;
+
+    return vec3<f32>(
+		 4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+		-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+		-0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s,
+    );
+}
+
+[[stage(fragment)]]
+fn fragment(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+    let speed = 2.0;
+    let t_1 = sin(time.time_since_startup * speed) * 0.5 + 0.5;
+    let t_2 = cos(time.time_since_startup * speed);
+
+    let distance_to_center = distance(in.uv, vec2<f32>(0.5)) * 1.4;
+
+    // blending is done in a perceptual color space: https://bottosson.github.io/posts/oklab/
+    let red = vec3<f32>(0.627955, 0.224863, 0.125846);
+    let green = vec3<f32>(0.86644, -0.233887, 0.179498);
+    let blue = vec3<f32>(0.701674, 0.274566, -0.169156);
+    let white = vec3<f32>(1.0, 0.0, 0.0);
+    let mixed = mix(mix(red, blue, t_1), mix(green, white, t_2), distance_to_center);
+
+    return vec4<f32>(oklab_to_linear_srgb(mixed), 1.0);
+}

--- a/assets/shaders/background.wgsl
+++ b/assets/shaders/background.wgsl
@@ -1,49 +1,39 @@
 // Import the standard 2d mesh uniforms and set their bind groups
-#import bevy_sprite::mesh2d_types
-#import bevy_sprite::mesh2d_view_bindings
-#import bevy_sprite::mesh2d_functions
-
-@group(1) @binding(0)
+#import bevy_sprite::mesh2d_view_bind_group
+[[group(0), binding(0)]]
+var<uniform> view: View;
+#import bevy_sprite::mesh2d_struct
+[[group(1), binding(0)]]
 var<uniform> mesh: Mesh2d;
 
 // The structure of the vertex buffer is as specified in `specialize()`
 struct Vertex {
-    @location(0) position: vec3<f32>;
-    @location(1) color: u32;
+    [[location(0)]] position: vec3<f32>;
+    [[location(1)]] color: u32;
 };
 
 struct Time {
     time_since_startup: f32;
 };
-@group(2) @binding(0)
+[[group(2), binding(0)]]
 var<uniform> time: Time;
 
 struct VertexOutput {
     // The vertex shader must set the on-screen position of the vertex
-    @builtin(position) clip_position: vec4<f32>;
+    [[builtin(position)]] clip_position: vec4<f32>;
     // We pass the vertex color to the framgent shader in location 0
-    @location(0) color: vec4<f32>;
+    [[location(0)]] color: vec4<f32>;
 };
 
-@stage(vertex)
+[[stage(vertex)]]
 fn vertex(vertex: Vertex) -> VertexOutput {
     var out: VertexOutput;
     // Project the world position of the mesh into screen position
-    out.clip_position = mesh2d_position_local_to_clip(mesh.model, vec4<f32>(vertex.position, 1.0));
+    out.clip_position = view.view_proj * mesh.model * vec4<f32>(vertex.position, 1.0);
     // Unpack the `u32` from the vertex buffer into the `vec4<f32>` used by the fragment shader
-    out.color = vec4<f32>((vec4<u32>(vertex.color) >> vec4<u32>(0u, 8u, 16u, 24u)) & vec4<u32>(255u))
+    out.color = vec4<f32>((vec4<u32>(vertex.color) >> vec4<u32>(0u, 8u, 16u, 24u)) & vec4<u32>(255u)) / 255.0;
     return out;
 }
-// fn vertex(vertex: Vertex) -> VertexOutput {
-//     var out: VertexOutput;
-//     let world_position = mesh.model * vec4<f32>(vertex.position, 1.0);
-//     // let world_position = vec4<f32>(vertex.position, 1.0);
-//     let position = view.view_proj * world_position;
-//     out.clip_position = position;
-//     // out.position = vertex.position;
-//     out.color = vec4<f32>
-//     return out;
-// }
 
 fn oklab_to_linear_srgb(c: vec3<f32>) -> vec3<f32> {
     let L = c.x;
@@ -65,32 +55,27 @@ fn oklab_to_linear_srgb(c: vec3<f32>) -> vec3<f32> {
 
 struct FragmentInput {
     // The color is interpolated between vertices by default
-    @location(0) color: vec4<f32>;
+    [[location(0)]] color: vec4<f32>;
 };
 
-@fragment
-fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
+[[stage(fragment)]]
+fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
+    // let speed_1 = 0.3;
+    // let speed_2 = 0.2;
+    // let time_since_startup = 0; // time.time_since_startup;
+    // let t_1 = sin(time_since_startup * speed_1) * 0.5 + 0.5;
+    // let t_2 = cos(time_since_startup * speed_2);
+
+    // let pos = vec2<f32>(in.position.x, in.position.y);
+    // let distance_to_center = distance(pos, vec2<f32>(t_2, t_1)) * 1.2;
+
+    // // blending is done in a perceptual color space: https://bottosson.github.io/posts/oklab/
+    // let red = vec3<f32>(0.627955, 0.224863, 0.125846);
+    // let green = vec3<f32>(0.86644, -0.233887, 0.179498);
+    // let blue = vec3<f32>(0.701674, 0.274566, -0.169156);
+    // let white = vec3<f32>(1.0, 0.0, 0.0);
+    // let mixed = mix(mix(red, blue, t_1), mix(green, white, t_2), distance_to_center);
+
+    // return vec4<f32>(oklab_to_linear_srgb(mixed), 1.0);
     return in.color;
 }
-
-// [[stage(fragment)]]
-// fn fragment(in: FragmentInput) -> [[location(0)]] vec4<f32> {
-//     let speed_1 = 0.3;
-//     let speed_2 = 0.2;
-//     let time_since_startup = time.time_since_startup;
-//     let t_1 = sin(time_since_startup * speed_1) * 0.5 + 0.5;
-//     let t_2 = cos(time_since_startup * speed_2);
-
-//     let pos = vec2<f32>(in.position.x, in.position.y);
-//     let distance_to_center = distance(pos, vec2<f32>(t_2, t_1)) * 1.2;
-
-//     // blending is done in a perceptual color space: https://bottosson.github.io/posts/oklab/
-//     let red = vec3<f32>(0.627955, 0.224863, 0.125846);
-//     let green = vec3<f32>(0.86644, -0.233887, 0.179498);
-//     let blue = vec3<f32>(0.701674, 0.274566, -0.169156);
-//     let white = vec3<f32>(1.0, 0.0, 0.0);
-//     let mixed = mix(mix(red, blue, t_1), mix(green, white, t_2), distance_to_center);
-
-//     return vec4<f32>(oklab_to_linear_srgb(mixed), 1.0);
-//     // return in.color;
-// }

--- a/ref/animate_shader.rs
+++ b/ref/animate_shader.rs
@@ -1,0 +1,261 @@
+use bevy::{
+    core_pipeline::Transparent3d,
+    ecs::system::{lifetimeless::SRes, SystemParamItem},
+    pbr::{
+        DrawMesh, MeshPipeline, MeshPipelineKey, MeshUniform, SetMeshBindGroup,
+        SetMeshViewBindGroup,
+    },
+    prelude::*,
+    render::{
+        mesh::MeshVertexBufferLayout,
+        render_asset::RenderAssets,
+        render_phase::{
+            AddRenderCommand, DrawFunctions, EntityRenderCommand, RenderCommandResult, RenderPhase,
+            SetItemPipeline, TrackedRenderPass,
+        },
+        render_resource::*,
+        renderer::{RenderDevice, RenderQueue},
+        view::{ComputedVisibility, ExtractedView, Msaa, Visibility},
+        RenderApp, RenderStage,
+    },
+};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(CustomMaterialPlugin)
+        .add_startup_system(setup)
+        .run();
+}
+
+fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
+    // cube
+    commands.spawn().insert_bundle((
+        meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        Transform::from_xyz(0.0, 0.5, 0.0),
+        GlobalTransform::default(),
+        CustomMaterial,
+        Visibility::default(),
+        ComputedVisibility::default(),
+    ));
+
+    // camera
+    commands.spawn_bundle(PerspectiveCameraBundle {
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+}
+
+#[derive(Component)]
+struct CustomMaterial;
+
+pub struct CustomMaterialPlugin;
+
+impl Plugin for CustomMaterialPlugin {
+    fn build(&self, app: &mut App) {
+        let render_device = app.world.resource::<RenderDevice>();
+        let buffer = render_device.create_buffer(&BufferDescriptor {
+            label: Some("time uniform buffer"),
+            size: std::mem::size_of::<f32>() as u64,
+            usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        app.sub_app_mut(RenderApp)
+            .add_render_command::<Transparent3d, DrawCustom>()
+            .insert_resource(TimeMeta {
+                buffer,
+                bind_group: None,
+            })
+            .init_resource::<CustomPipeline>()
+            .init_resource::<SpecializedMeshPipelines<CustomPipeline>>()
+            .add_system_to_stage(RenderStage::Extract, extract_time)
+            .add_system_to_stage(RenderStage::Extract, extract_custom_material)
+            .add_system_to_stage(RenderStage::Prepare, prepare_time)
+            .add_system_to_stage(RenderStage::Queue, queue_custom)
+            .add_system_to_stage(RenderStage::Queue, queue_time_bind_group);
+    }
+}
+
+// extract the `CustomMaterial` component into the render world
+fn extract_custom_material(
+    mut commands: Commands,
+    mut previous_len: Local<usize>,
+    mut query: Query<Entity, With<CustomMaterial>>,
+) {
+    let mut values = Vec::with_capacity(*previous_len);
+    for entity in query.iter_mut() {
+        values.push((entity, (CustomMaterial,)));
+    }
+    *previous_len = values.len();
+    commands.insert_or_spawn_batch(values);
+}
+
+// add each entity with a mesh and a `CustomMaterial` to every view's `Transparent3d` render phase using the `CustomPipeline`
+#[allow(clippy::too_many_arguments)]
+fn queue_custom(
+    transparent_3d_draw_functions: Res<DrawFunctions<Transparent3d>>,
+    custom_pipeline: Res<CustomPipeline>,
+    msaa: Res<Msaa>,
+    mut pipelines: ResMut<SpecializedMeshPipelines<CustomPipeline>>,
+    mut pipeline_cache: ResMut<PipelineCache>,
+    render_meshes: Res<RenderAssets<Mesh>>,
+    material_meshes: Query<(Entity, &MeshUniform, &Handle<Mesh>), With<CustomMaterial>>,
+    mut views: Query<(&ExtractedView, &mut RenderPhase<Transparent3d>)>,
+) {
+    let draw_custom = transparent_3d_draw_functions
+        .read()
+        .get_id::<DrawCustom>()
+        .unwrap();
+
+    let key = MeshPipelineKey::from_msaa_samples(msaa.samples)
+        | MeshPipelineKey::from_primitive_topology(PrimitiveTopology::TriangleList);
+
+    for (view, mut transparent_phase) in views.iter_mut() {
+        let view_matrix = view.transform.compute_matrix();
+        let view_row_2 = view_matrix.row(2);
+        for (entity, mesh_uniform, mesh_handle) in material_meshes.iter() {
+            if let Some(mesh) = render_meshes.get(mesh_handle) {
+                let pipeline = pipelines
+                    .specialize(&mut pipeline_cache, &custom_pipeline, key, &mesh.layout)
+                    .unwrap();
+                transparent_phase.add(Transparent3d {
+                    entity,
+                    pipeline,
+                    draw_function: draw_custom,
+                    distance: view_row_2.dot(mesh_uniform.transform.col(3)),
+                });
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct ExtractedTime {
+    seconds_since_startup: f32,
+}
+
+// extract the passed time into a resource in the render world
+fn extract_time(mut commands: Commands, time: Res<Time>) {
+    commands.insert_resource(ExtractedTime {
+        seconds_since_startup: time.seconds_since_startup() as f32,
+    });
+}
+
+struct TimeMeta {
+    buffer: Buffer,
+    bind_group: Option<BindGroup>,
+}
+
+// write the extracted time into the corresponding uniform buffer
+fn prepare_time(
+    time: Res<ExtractedTime>,
+    time_meta: ResMut<TimeMeta>,
+    render_queue: Res<RenderQueue>,
+) {
+    render_queue.write_buffer(
+        &time_meta.buffer,
+        0,
+        bevy::core::cast_slice(&[time.seconds_since_startup]),
+    );
+}
+
+// create a bind group for the time uniform buffer
+fn queue_time_bind_group(
+    render_device: Res<RenderDevice>,
+    mut time_meta: ResMut<TimeMeta>,
+    pipeline: Res<CustomPipeline>,
+) {
+    let bind_group = render_device.create_bind_group(&BindGroupDescriptor {
+        label: None,
+        layout: &pipeline.time_bind_group_layout,
+        entries: &[BindGroupEntry {
+            binding: 0,
+            resource: time_meta.buffer.as_entire_binding(),
+        }],
+    });
+    time_meta.bind_group = Some(bind_group);
+}
+
+pub struct CustomPipeline {
+    shader: Handle<Shader>,
+    mesh_pipeline: MeshPipeline,
+    time_bind_group_layout: BindGroupLayout,
+}
+
+impl FromWorld for CustomPipeline {
+    fn from_world(world: &mut World) -> Self {
+        let world = world.cell();
+        let asset_server = world.get_resource::<AssetServer>().unwrap();
+        let shader = asset_server.load("shaders/animate_shader.wgsl");
+
+        let render_device = world.get_resource_mut::<RenderDevice>().unwrap();
+        let time_bind_group_layout =
+            render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+                label: Some("time bind group"),
+                entries: &[BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::FRAGMENT,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: BufferSize::new(std::mem::size_of::<f32>() as u64),
+                    },
+                    count: None,
+                }],
+            });
+
+        let mesh_pipeline = world.get_resource::<MeshPipeline>().unwrap();
+
+        CustomPipeline {
+            shader,
+            mesh_pipeline: mesh_pipeline.clone(),
+            time_bind_group_layout,
+        }
+    }
+}
+
+impl SpecializedMeshPipeline for CustomPipeline {
+    type Key = MeshPipelineKey;
+
+    fn specialize(
+        &self,
+        key: Self::Key,
+        layout: &MeshVertexBufferLayout,
+    ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
+        let mut descriptor = self.mesh_pipeline.specialize(key, layout)?;
+        descriptor.vertex.shader = self.shader.clone();
+        descriptor.fragment.as_mut().unwrap().shader = self.shader.clone();
+        descriptor.layout = Some(vec![
+            self.mesh_pipeline.view_layout.clone(),
+            self.mesh_pipeline.mesh_layout.clone(),
+            self.time_bind_group_layout.clone(),
+        ]);
+        Ok(descriptor)
+    }
+}
+
+type DrawCustom = (
+    SetItemPipeline,
+    SetMeshViewBindGroup<0>,
+    SetMeshBindGroup<1>,
+    SetTimeBindGroup<2>,
+    DrawMesh,
+);
+
+struct SetTimeBindGroup<const I: usize>;
+impl<const I: usize> EntityRenderCommand for SetTimeBindGroup<I> {
+    type Param = SRes<TimeMeta>;
+
+    fn render<'w>(
+        _view: Entity,
+        _item: Entity,
+        time_meta: SystemParamItem<'w, '_, Self::Param>,
+        pass: &mut TrackedRenderPass<'w>,
+    ) -> RenderCommandResult {
+        let time_bind_group = time_meta.into_inner().bind_group.as_ref().unwrap();
+        pass.set_bind_group(I, time_bind_group, &[]);
+
+        RenderCommandResult::Success
+    }
+}

--- a/src/background.rs
+++ b/src/background.rs
@@ -101,23 +101,32 @@ impl SpecializedRenderPipeline for ColoredMesh2dPipeline {
     fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
         // Customize how to store the meshes' vertex attributes in the vertex buffer
         // Our meshes only have position and color
-        let vertex_attributes = vec![
-            VertexAttribute {
-                format: VertexFormat::Float32x3,
-                // this offset is the size of the color attribute, which is stored first
-                offset: 16,
-                // position is available at location 0 in the shader
-                shader_location: 0,
-            },
-            // Color
-            VertexAttribute {
-                format: VertexFormat::Float32x4,
-                offset: 0,
-                shader_location: 1,
-            },
-        ];
+        // let vertex_attributes = vec![
+        //     VertexAttribute {
+        //         format: VertexFormat::Float32x3,
+        //         // this offset is the size of the color attribute, which is stored first
+        //         offset: 16,
+        //         // position is available at location 0 in the shader
+        //         shader_location: 0,
+        //     },
+        //     // Color
+        //     VertexAttribute {
+        //         format: VertexFormat::Float32x4,
+        //         offset: 0,
+        //         shader_location: 1,
+        //     },
+        // ];
         // This is the sum of the size of position and color attributes (12 + 16 = 28)
-        let vertex_array_stride = 28;
+        // let vertex_array_stride = 28;
+
+        let formats = vec![
+            VertexFormat::Float32x3,
+            // VertexFormat::Float32x4,
+            VertexFormat::Uint32,
+        ];
+
+        let vertex_layout =
+            VertexBufferLayout::from_vertex_formats(VertexStepMode::Vertex, formats);
 
         RenderPipelineDescriptor {
             vertex: VertexState {
@@ -126,11 +135,12 @@ impl SpecializedRenderPipeline for ColoredMesh2dPipeline {
                 entry_point: "vertex".into(),
                 shader_defs: Vec::new(),
                 // Use our custom vertex buffer
-                buffers: vec![VertexBufferLayout {
-                    array_stride: vertex_array_stride,
-                    step_mode: VertexStepMode::Vertex,
-                    attributes: vertex_attributes,
-                }],
+                // buffers: vec![VertexBufferLayout {
+                //     array_stride: vertex_array_stride,
+                //     step_mode: VertexStepMode::Vertex,
+                //     attributes: vertex_attributes,
+                // }],
+                buffers: vec![vertex_layout],
             },
             fragment: Some(FragmentState {
                 // Use our custom shader

--- a/src/background.rs
+++ b/src/background.rs
@@ -31,8 +31,8 @@ pub fn setup_background(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>
         [1.0, -1.0, 0.0],
     ];
     rect.insert_attribute(Mesh::ATTRIBUTE_POSITION, v_pos);
-    let mut v_color = vec![[0.0, 0.0, 0.0, 1.0]];
-    v_color.extend_from_slice(&[[1.0, 1.0, 0.0, 1.0]; 3]);
+    let mut v_color: Vec<u32> = vec![Color::BLACK.as_linear_rgba_u32()];
+    v_color.extend_from_slice(&[Color::YELLOW.as_linear_rgba_u32(); 3]);
     rect.insert_attribute(Mesh::ATTRIBUTE_COLOR, v_color);
     let mut indices = vec![0, 1, 4];
     for i in 2..=4 {
@@ -65,8 +65,8 @@ pub struct ColoredMesh2dPipeline {
 
 impl FromWorld for ColoredMesh2dPipeline {
     fn from_world(world: &mut World) -> Self {
-        let world = world.cell();
-        let asset_server = world.get_resource::<AssetServer>().unwrap();
+        // let world = world.cell();
+        let asset_server = world.resource::<AssetServer>();
         let shader = asset_server.load("shaders/background.wgsl");
 
         let render_device = world.get_resource_mut::<RenderDevice>().unwrap();

--- a/src/background.rs
+++ b/src/background.rs
@@ -4,7 +4,7 @@ use bevy::{
     ecs::system::{lifetimeless::SRes, SystemParamItem},
     prelude::*,
     render::{
-        mesh::Indices,
+        mesh::{Indices, MeshVertexBufferLayout},
         render_asset::RenderAssets,
         render_phase::{
             AddRenderCommand, DrawFunctions, EntityRenderCommand, RenderCommandResult, RenderPhase,
@@ -12,9 +12,10 @@ use bevy::{
         },
         render_resource::*,
         renderer::{RenderDevice, RenderQueue},
-        texture::BevyDefault,
+        // texture::BevyDefault,
         view::VisibleEntities,
-        RenderApp, RenderStage,
+        RenderApp,
+        RenderStage,
     },
     sprite::{
         DrawMesh2d, Mesh2dHandle, Mesh2dPipeline, Mesh2dPipelineKey, Mesh2dUniform,
@@ -65,11 +66,9 @@ pub struct ColoredMesh2dPipeline {
 
 impl FromWorld for ColoredMesh2dPipeline {
     fn from_world(world: &mut World) -> Self {
-        let world = world.cell();
-        let asset_server = world.get_resource::<AssetServer>().unwrap();
+        let asset_server = world.resource::<AssetServer>();
         let shader = asset_server.load("shaders/background.wgsl");
-
-        let render_device = world.get_resource_mut::<RenderDevice>().unwrap();
+        let render_device = world.resource_mut::<RenderDevice>();
         let time_bind_group_layout =
             render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
                 label: Some("time bind group"),
@@ -84,7 +83,7 @@ impl FromWorld for ColoredMesh2dPipeline {
                     count: None,
                 }],
             });
-        let mesh2d_pipeline = world.get_resource::<Mesh2dPipeline>().unwrap().clone();
+        let mesh2d_pipeline = world.resource::<Mesh2dPipeline>().clone();
 
         Self {
             shader,
@@ -95,89 +94,23 @@ impl FromWorld for ColoredMesh2dPipeline {
 }
 
 // We implement `SpecializedPipeline` to customize the default rendering from `Mesh2dPipeline`
-impl SpecializedRenderPipeline for ColoredMesh2dPipeline {
+impl SpecializedMeshPipeline for ColoredMesh2dPipeline {
     type Key = Mesh2dPipelineKey;
 
-    fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
-        // Customize how to store the meshes' vertex attributes in the vertex buffer
-        // Our meshes only have position and color
-        // let vertex_attributes = vec![
-        //     VertexAttribute {
-        //         format: VertexFormat::Float32x3,
-        //         // this offset is the size of the color attribute, which is stored first
-        //         offset: 16,
-        //         // position is available at location 0 in the shader
-        //         shader_location: 0,
-        //     },
-        //     // Color
-        //     VertexAttribute {
-        //         format: VertexFormat::Float32x4,
-        //         offset: 0,
-        //         shader_location: 1,
-        //     },
-        // ];
-        // This is the sum of the size of position and color attributes (12 + 16 = 28)
-        // let vertex_array_stride = 28;
-
-        let formats = vec![
-            VertexFormat::Float32x3,
-            // VertexFormat::Float32x4,
-            VertexFormat::Uint32,
-        ];
-
-        let vertex_layout =
-            VertexBufferLayout::from_vertex_formats(VertexStepMode::Vertex, formats);
-
-        RenderPipelineDescriptor {
-            vertex: VertexState {
-                // Use our custom shader
-                shader: self.shader.clone(),
-                entry_point: "vertex".into(),
-                shader_defs: Vec::new(),
-                // Use our custom vertex buffer
-                // buffers: vec![VertexBufferLayout {
-                //     array_stride: vertex_array_stride,
-                //     step_mode: VertexStepMode::Vertex,
-                //     attributes: vertex_attributes,
-                // }],
-                buffers: vec![vertex_layout],
-            },
-            fragment: Some(FragmentState {
-                // Use our custom shader
-                shader: self.shader.clone(),
-                shader_defs: Vec::new(),
-                entry_point: "fragment".into(),
-                targets: vec![ColorTargetState {
-                    format: TextureFormat::bevy_default(),
-                    blend: Some(BlendState::ALPHA_BLENDING),
-                    write_mask: ColorWrites::ALL,
-                }],
-            }),
-            // Use the two standard uniforms for 2d meshes
-            layout: Some(vec![
-                // Bind group 0 is the view uniform
-                self.mesh2d_pipeline.view_layout.clone(),
-                // Bind group 1 is the mesh uniform
-                self.mesh2d_pipeline.mesh_layout.clone(),
-                self.time_bind_group_layout.clone(),
-            ]),
-            primitive: PrimitiveState {
-                front_face: FrontFace::Ccw,
-                cull_mode: Some(Face::Back),
-                unclipped_depth: false,
-                polygon_mode: PolygonMode::Fill,
-                conservative: false,
-                topology: key.primitive_topology(),
-                strip_index_format: None,
-            },
-            depth_stencil: None,
-            multisample: MultisampleState {
-                count: key.msaa_samples(),
-                mask: !0,
-                alpha_to_coverage_enabled: false,
-            },
-            label: Some("colored_mesh2d_pipeline".into()),
-        }
+    fn specialize(
+        &self,
+        key: Self::Key,
+        layout: &MeshVertexBufferLayout,
+    ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
+        let mut descriptor = self.mesh2d_pipeline.specialize(key, layout)?;
+        descriptor.vertex.shader = self.shader.clone();
+        descriptor.fragment.as_mut().unwrap().shader = self.shader.clone();
+        descriptor.layout = Some(vec![
+            self.mesh2d_pipeline.view_layout.clone(),
+            self.mesh2d_pipeline.mesh_layout.clone(),
+            self.time_bind_group_layout.clone(),
+        ]);
+        Ok(descriptor)
     }
 }
 
@@ -200,7 +133,7 @@ pub struct ColoredMesh2dPlugin;
 
 impl Plugin for ColoredMesh2dPlugin {
     fn build(&self, app: &mut App) {
-        let render_device = app.world.get_resource::<RenderDevice>().unwrap();
+        let render_device = app.world.resource::<RenderDevice>();
         let buffer = render_device.create_buffer(&BufferDescriptor {
             label: Some("time uniform buffer"),
             size: std::mem::size_of::<f32>() as u64,
@@ -217,7 +150,7 @@ impl Plugin for ColoredMesh2dPlugin {
                 bind_group: None,
             })
             .init_resource::<ColoredMesh2dPipeline>()
-            .init_resource::<SpecializedRenderPipelines<ColoredMesh2dPipeline>>()
+            .init_resource::<SpecializedMeshPipelines<ColoredMesh2dPipeline>>()
             .add_system_to_stage(RenderStage::Extract, extract_time)
             .add_system_to_stage(RenderStage::Extract, extract_colored_mesh2d)
             .add_system_to_stage(RenderStage::Prepare, prepare_time)
@@ -249,7 +182,7 @@ pub fn extract_colored_mesh2d(
 pub fn queue_colored_mesh2d(
     transparent_draw_functions: Res<DrawFunctions<Transparent2d>>,
     colored_mesh2d_pipeline: Res<ColoredMesh2dPipeline>,
-    mut pipelines: ResMut<SpecializedRenderPipelines<ColoredMesh2dPipeline>>,
+    mut pipelines: ResMut<SpecializedMeshPipelines<ColoredMesh2dPipeline>>,
     mut pipeline_cache: ResMut<PipelineCache>,
     msaa: Res<Msaa>,
     render_meshes: Res<RenderAssets<Mesh>>,
@@ -276,22 +209,28 @@ pub fn queue_colored_mesh2d(
                 if let Some(mesh) = render_meshes.get(&mesh2d_handle.0) {
                     mesh2d_key |=
                         Mesh2dPipelineKey::from_primitive_topology(mesh.primitive_topology);
+
+                    let pipeline = pipelines
+                        .specialize(
+                            &mut pipeline_cache,
+                            &colored_mesh2d_pipeline,
+                            mesh2d_key,
+                            &mesh.layout,
+                        )
+                        .unwrap();
+
+                    let mesh_z = mesh2d_uniform.transform.w_axis.z;
+                    transparent_phase.add(Transparent2d {
+                        entity: *visible_entity,
+                        draw_function: draw_colored_mesh2d,
+                        pipeline,
+                        // The 2d render items are sorted according to their z value before rendering,
+                        // in order to get correct transparency
+                        sort_key: FloatOrd(mesh_z),
+                        // This material is not batched
+                        batch_range: None,
+                    });
                 }
-
-                let pipeline_id =
-                    pipelines.specialize(&mut pipeline_cache, &colored_mesh2d_pipeline, mesh2d_key);
-
-                let mesh_z = mesh2d_uniform.transform.w_axis.z;
-                transparent_phase.add(Transparent2d {
-                    entity: *visible_entity,
-                    draw_function: draw_colored_mesh2d,
-                    pipeline: pipeline_id,
-                    // The 2d render items are sorted according to their z value before rendering,
-                    // in order to get correct transparency
-                    sort_key: FloatOrd(mesh_z),
-                    // This material is not batched
-                    batch_range: None,
-                });
             }
         }
     }

--- a/src/background.rs
+++ b/src/background.rs
@@ -123,6 +123,8 @@ impl SpecializedRenderPipeline for ColoredMesh2dPipeline {
             VertexFormat::Float32x3,
             // VertexFormat::Float32x4,
             VertexFormat::Uint32,
+            // for time
+            VertexFormat::Uint32,
         ];
 
         let vertex_layout =
@@ -200,13 +202,18 @@ pub struct ColoredMesh2dPlugin;
 
 impl Plugin for ColoredMesh2dPlugin {
     fn build(&self, app: &mut App) {
-        let render_device = app.world.get_resource::<RenderDevice>().unwrap();
+        let render_device = app.world.resource::<RenderDevice>();
         let buffer = render_device.create_buffer(&BufferDescriptor {
             label: Some("time uniform buffer"),
             size: std::mem::size_of::<f32>() as u64,
             usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
+        // let shaders = app.world.resource_mut::<Assets<Shader>>();
+        // shaders.set_untracked(
+        //     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 202207222221),
+        //     Shader::from_wgsl(),
+        // );
 
         // Register our custom draw function and pipeline, and add our render systems
         let render_app = app.get_sub_app_mut(RenderApp).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
             just_changed: None,
         })
         .insert_resource(ClearColor(Color::rgb(0.9, 0.9, 0.9)))
-        // .add_plugin(ColoredMesh2dPlugin)
+        .add_plugin(ColoredMesh2dPlugin)
         .add_startup_system(setup)
         .add_system_set(
             SystemSet::new()


### PR DESCRIPTION
### based on 2D

- https://github.com/bevyengine/bevy/blob/main/examples/2d/mesh2d_manual.rs

```diff
diff --git a/examples/2d/mesh2d_manual.rs b/examples/2d/mesh2d_manual.rs
index 37164583..e4cc86d8 100644
--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -9,9 +9,9 @@ use bevy::{
         render_phase::{AddRenderCommand, DrawFunctions, RenderPhase, SetItemPipeline},
         render_resource::{
             BlendState, ColorTargetState, ColorWrites, Face, FragmentState, FrontFace,
-            MultisampleState, PolygonMode, PrimitiveState, PrimitiveTopology, RenderPipelineCache,
-            RenderPipelineDescriptor, SpecializedPipeline, SpecializedPipelines, TextureFormat,
-            VertexAttribute, VertexBufferLayout, VertexFormat, VertexState, VertexStepMode,
+            MultisampleState, PipelineCache, PolygonMode, PrimitiveState, PrimitiveTopology,
+            RenderPipelineDescriptor, SpecializedRenderPipeline, SpecializedRenderPipelines,
+            TextureFormat, VertexBufferLayout, VertexFormat, VertexState, VertexStepMode,
         },
         texture::BevyDefault,
         view::VisibleEntities,
@@ -68,11 +68,11 @@ fn star(
         v_pos.push([r * a.cos(), r * a.sin(), 0.0]);
     }
     // Set the position attribute
-    star.set_attribute(Mesh::ATTRIBUTE_POSITION, v_pos);
+    star.insert_attribute(Mesh::ATTRIBUTE_POSITION, v_pos);
     // And a RGB color attribute as well
-    let mut v_color = vec![[0.0, 0.0, 0.0, 1.0]];
-    v_color.extend_from_slice(&[[1.0, 1.0, 0.0, 1.0]; 10]);
-    star.set_attribute(Mesh::ATTRIBUTE_COLOR, v_color);
+    let mut v_color: Vec<u32> = vec![Color::BLACK.as_linear_rgba_u32()];
+    v_color.extend_from_slice(&[Color::YELLOW.as_linear_rgba_u32(); 10]);
+    star.insert_attribute(Mesh::ATTRIBUTE_COLOR, v_color);

     // Now, we specify the indices of the vertex that are going to compose the
     // triangles in our star. Vertices in triangles have to be specified in CCW

@@ -125,30 +125,21 @@ impl FromWorld for ColoredMesh2dPipeline {
 }

 // We implement `SpecializedPipeline` to customize the default rendering from `Mesh2dPipeline`
-impl SpecializedPipeline for ColoredMesh2dPipeline {
+impl SpecializedRenderPipeline for ColoredMesh2dPipeline {
     type Key = Mesh2dPipelineKey;

     fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
         // Customize how to store the meshes' vertex attributes in the vertex buffer
         // Our meshes only have position and color
-        let vertex_attributes = vec![
-            // Position (GOTCHA! Vertex_Position isn't first in the buffer due to how Mesh sorts attributes (alphabetically))
-            VertexAttribute {
-                format: VertexFormat::Float32x3,
-                // this offset is the size of the color attribute, which is stored first
-                offset: 16,
-                // position is available at location 0 in the shader
-                shader_location: 0,
-            },
+        let formats = vec![
+            // Position
+            VertexFormat::Float32x3,
             // Color
-            VertexAttribute {
-                format: VertexFormat::Float32x4,
-                offset: 0,
-                shader_location: 1,
-            },
+            VertexFormat::Uint32,
         ];
-        // This is the sum of the size of position and color attributes (12 + 16 = 28)
-        let vertex_array_stride = 28;
+
+        let vertex_layout =
+            VertexBufferLayout::from_vertex_formats(VertexStepMode::Vertex, formats);

         RenderPipelineDescriptor {
             vertex: VertexState {

@@ -157,11 +148,7 @@ impl SpecializedPipeline for ColoredMesh2dPipeline {
                 entry_point: "vertex".into(),
                 shader_defs: Vec::new(),
                 // Use our custom vertex buffer
-                buffers: vec![VertexBufferLayout {
-                    array_stride: vertex_array_stride,
-                    step_mode: VertexStepMode::Vertex,
-                    attributes: vertex_attributes,
-                }],
+                buffers: vec![vertex_layout],
             },
             fragment: Some(FragmentState {
                 // Use our custom shader
@@ -227,13 +214,13 @@ var<uniform> mesh: Mesh2d;
 // The structure of the vertex buffer is as specified in `specialize()`
 struct Vertex {
     [[location(0)]] position: vec3<f32>;
-    [[location(1)]] color: vec4<f32>;
+    [[location(1)]] color: u32;
 };

 struct VertexOutput {
     // The vertex shader must set the on-screen position of the vertex
     [[builtin(position)]] clip_position: vec4<f32>;
-    // We pass the vertex color to the framgent shader in location 0
+    // We pass the vertex color to the fragment shader in location 0
     [[location(0)]] color: vec4<f32>;
 };

@@ -243,7 +230,8 @@ fn vertex(vertex: Vertex) -> VertexOutput {
     var out: VertexOutput;
     // Project the world position of the mesh into screen position
     out.clip_position = view.view_proj * mesh.model * vec4<f32>(vertex.position, 1.0);
-    out.color = vertex.color;
+    // Unpack the `u32` from the vertex buffer into the `vec4<f32>` used by the fragment shader
+    out.color = vec4<f32>((vec4<u32>(vertex.color) >> vec4<u32>(0u, 8u, 16u, 24u)) & vec4<u32>(255u)) / 255.0;
     return out;
 }


@@ -270,7 +258,7 @@ pub const COLORED_MESH2D_SHADER_HANDLE: HandleUntyped =
 impl Plugin for ColoredMesh2dPlugin {
     fn build(&self, app: &mut App) {
         // Load our custom shader
-        let mut shaders = app.world.get_resource_mut::<Assets<Shader>>().unwrap();
+        let mut shaders = app.world.resource_mut::<Assets<Shader>>();
         shaders.set_untracked(
             COLORED_MESH2D_SHADER_HANDLE,
             Shader::from_wgsl(COLORED_MESH2D_SHADER),
@@ -281,7 +269,7 @@ impl Plugin for ColoredMesh2dPlugin {
         render_app
             .add_render_command::<Transparent2d, DrawColoredMesh2d>()
             .init_resource::<ColoredMesh2dPipeline>()
-            .init_resource::<SpecializedPipelines<ColoredMesh2dPipeline>>()
+            .init_resource::<SpecializedRenderPipelines<ColoredMesh2dPipeline>>()
             .add_system_to_stage(RenderStage::Extract, extract_colored_mesh2d)
             .add_system_to_stage(RenderStage::Queue, queue_colored_mesh2d);
     }
@@ -309,8 +297,8 @@ pub fn extract_colored_mesh2d(
 pub fn queue_colored_mesh2d(
     transparent_draw_functions: Res<DrawFunctions<Transparent2d>>,
     colored_mesh2d_pipeline: Res<ColoredMesh2dPipeline>,
-    mut pipelines: ResMut<SpecializedPipelines<ColoredMesh2dPipeline>>,
-    mut pipeline_cache: ResMut<RenderPipelineCache>,
+    mut pipelines: ResMut<SpecializedRenderPipelines<ColoredMesh2dPipeline>>,
+    mut pipeline_cache: ResMut<PipelineCache>,
     msaa: Res<Msaa>,
     render_meshes: Res<RenderAssets<Mesh>>,
     colored_mesh2d: Query<(&Mesh2dHandle, &Mesh2dUniform), With<ColoredMesh2d>>,
```

### based on 3d

- https://github.com/bevyengine/bevy/blob/main/examples/shader/animate_shader.rs

from v0.6.0 to v0.7.0
```diff
iff --git a/examples/shader/animate_shader.rs b/examples/shader/animate_shader.rs
index 6e8f4b00..abdf5faf 100644
--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -7,6 +7,8 @@ use bevy::{
     },
     prelude::*,
     render::{
+        mesh::MeshVertexBufferLayout,
+        render_asset::RenderAssets,
         render_phase::{
             AddRenderCommand, DrawFunctions, EntityRenderCommand, RenderCommandResult, RenderPhase,
             SetItemPipeline, TrackedRenderPass,
@@ -40,7 +42,7 @@ fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
     // camera
     commands.spawn_bundle(PerspectiveCameraBundle {
         transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }
@@ -51,7 +53,7 @@ pub struct CustomMaterialPlugin;
 impl Plugin for CustomMaterialPlugin {
     fn build(&self, app: &mut App) {
-        let render_device = app.world.get_resource::<RenderDevice>().unwrap();
+        let render_device = app.world.resource::<RenderDevice>();
         let buffer = render_device.create_buffer(&BufferDescriptor {
             label: Some("time uniform buffer"),
             size: std::mem::size_of::<f32>() as u64,
@@ -66,7 +68,7 @@ impl Plugin for CustomMaterialPlugin {
                 bind_group: None,
             })
             .init_resource::<CustomPipeline>()
-            .init_resource::<SpecializedPipelines<CustomPipeline>>()
+            .init_resource::<SpecializedMeshPipelines<CustomPipeline>>()
             .add_system_to_stage(RenderStage::Extract, extract_time)
             .add_system_to_stage(RenderStage::Extract, extract_custom_material)
             .add_system_to_stage(RenderStage::Prepare, prepare_time)
@@ -90,13 +92,15 @@ fn extract_custom_material(
 }
 // add each entity with a mesh and a `CustomMaterial` to every view's `Transparent3d` render phase using the `Cu
stomPipeline`
+#[allow(clippy::too_many_arguments)]
 fn queue_custom(
     transparent_3d_draw_functions: Res<DrawFunctions<Transparent3d>>,
     custom_pipeline: Res<CustomPipeline>,
     msaa: Res<Msaa>,
-    mut pipelines: ResMut<SpecializedPipelines<CustomPipeline>>,
-    mut pipeline_cache: ResMut<RenderPipelineCache>,
-    material_meshes: Query<(Entity, &MeshUniform), (With<Handle<Mesh>>, With<CustomMaterial>)>,
+    mut pipelines: ResMut<SpecializedMeshPipelines<CustomPipeline>>,
+    mut pipeline_cache: ResMut<PipelineCache>,
+    render_meshes: Res<RenderAssets<Mesh>>,
+    material_meshes: Query<(Entity, &MeshUniform, &Handle<Mesh>), With<CustomMaterial>>,
     mut views: Query<(&ExtractedView, &mut RenderPhase<Transparent3d>)>,
 ) {
     let draw_custom = transparent_3d_draw_functions
@@ -106,18 +110,22 @@ fn queue_custom(
     let key = MeshPipelineKey::from_msaa_samples(msaa.samples)
         | MeshPipelineKey::from_primitive_topology(PrimitiveTopology::TriangleList);
-    let pipeline = pipelines.specialize(&mut pipeline_cache, &custom_pipeline, key);
     for (view, mut transparent_phase) in views.iter_mut() {
         let view_matrix = view.transform.compute_matrix();
         let view_row_2 = view_matrix.row(2);
-        for (entity, mesh_uniform) in material_meshes.iter() {
-            transparent_phase.add(Transparent3d {
-                entity,
-                pipeline,
-                draw_function: draw_custom,
-                distance: view_row_2.dot(mesh_uniform.transform.col(3)),
-            });
+        for (entity, mesh_uniform, mesh_handle) in material_meshes.iter() {
+            if let Some(mesh) = render_meshes.get(mesh_handle) {
+                let pipeline = pipelines
+                    .specialize(&mut pipeline_cache, &custom_pipeline, key, &mesh.layout)
+                    .unwrap();
+                transparent_phase.add(Transparent3d {
+                    entity,
+                    pipeline,
+                    draw_function: draw_custom,
+                    distance: view_row_2.dot(mesh_uniform.transform.col(3)),
+                });
+            }
         }
     }
 }
@@ -207,11 +215,15 @@ impl FromWorld for CustomPipeline {
     }
 }
-impl SpecializedPipeline for CustomPipeline {
+impl SpecializedMeshPipeline for CustomPipeline {
     type Key = MeshPipelineKey;
-    fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
-        let mut descriptor = self.mesh_pipeline.specialize(key);
+    fn specialize(
+        &self,
+        key: Self::Key,
+        layout: &MeshVertexBufferLayout,
+    ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
+        let mut descriptor = self.mesh_pipeline.specialize(key, layout)?;
         descriptor.vertex.shader = self.shader.clone();
         descriptor.fragment.as_mut().unwrap().shader = self.shader.clone();
         descriptor.layout = Some(vec![
@@ -219,7 +231,7 @@ impl SpecializedPipeline for CustomPipeline {
             self.mesh_pipeline.mesh_layout.clone(),
             self.time_bind_group_layout.clone(),
         ]);
-        descriptor
+        Ok(descriptor)
     }
 }
`
```